### PR TITLE
Refactor BuildProcessor to take all input files

### DIFF
--- a/ContentPipe.Core/BuildProcessor.cs
+++ b/ContentPipe.Core/BuildProcessor.cs
@@ -1,58 +1,417 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace ContentPipe.Core
 {
     /// <summary>
+    /// Represents options for the current build
+    /// </summary>
+    public struct BuildOptions
+    {
+        /// <summary>
+        /// The input asset directory
+        /// </summary>
+        public string inputDirectory;
+
+        /// <summary>
+        /// The output asset directory
+        /// </summary>
+        public string outputDirectory;
+
+        /// <summary>
+        /// Settings for Parallel functions
+        /// </summary>
+        public ParallelOptions parallelOptions;
+    }
+
+    /// <summary>
+    /// Build input file data
+    /// </summary>
+    public struct BuildInputFile
+    {
+        /// <summary>
+        /// The input file path
+        /// </summary>
+        public string filepath;
+
+        /// <summary>
+        /// The input file meta path, or null if there is no meta file
+        /// </summary>
+        public string metapath;
+    }
+
+    /// <summary>
+    /// Build input file with JSON metadata
+    /// </summary>
+    /// <typeparam name="TMetadata">The metadata type</typeparam>
+    public struct BuildInputFile<TMetadata>
+    {
+        /// <summary>
+        /// The input file path
+        /// </summary>
+        public string filepath;
+
+        /// <summary>
+        /// The input file meta path, or null if there is no meta file
+        /// </summary>
+        public string metapath;
+
+        /// <summary>
+        /// The deserialized metadata
+        /// </summary>
+        public TMetadata metadata;
+    }
+
+    /// <summary>
     /// Base class for a processor which operates on content files
     /// </summary>
     public abstract class BuildProcessor
     {
-        public virtual string GetOutputExtension(string inFileExtension)
+        /// <summary>
+        /// Process input files using the given build options
+        /// </summary>
+        /// <param name="inputFiles">The input files to process</param>
+        /// <param name="options">The build options to use</param>
+        /// <returns>Number of errors to report, or 0 if all succeeded</returns>
+        public abstract int Process(BuildInputFile[] inputFiles, BuildOptions options);
+
+        /// <summary>
+        /// Make a path relative to another
+        /// </summary>
+        /// <param name="filepath">The full path</param>
+        /// <param name="relativeTo">The path to make it relative to</param>
+        /// <returns>The relative path</returns>
+        protected static string MakeRelativePath(string filepath, string relativeTo)
         {
-            return inFileExtension;
+            Uri fullpath = new Uri(Path.GetFullPath(filepath));
+            Uri relpath = new Uri(Path.GetFullPath(relativeTo));
+            return relpath.MakeRelativeUri(fullpath).ToString();
         }
 
-        public abstract void Process(string infile, string infileMetadata, string outfile);
+        /// <summary>
+        /// Transform a path from input directory to output directory
+        /// </summary>
+        /// <param name="filepath">The file path</param>
+        /// <param name="srcDir">The input directory</param>
+        /// <param name="outDir">The output directory</param>
+        /// <returns>The destination path for the file</returns>
+        protected static string GetOutputPath(string filepath, string srcDir, string outDir)
+        {
+            return Path.Combine(outDir, MakeRelativePath(filepath, srcDir));
+        }
+
+        /// <summary>
+        /// Check if the given file is newer than the given output file and needs rebuilding
+        /// </summary>
+        /// <param name="filepath">The file path</param>
+        /// <param name="metapath">The file's metadata path</param>
+        /// <param name="outpath">The output file to compare against</param>
+        /// <returns>True if either the input file or its metadata file are newer, false otherwise</returns>
+        protected static bool CheckFileDirty(string filepath, string metapath, string outpath)
+        {
+            bool inFileDirty = File.GetLastWriteTime(filepath) > File.GetLastWriteTime(outpath);
+            bool inMetaDirty = File.Exists(metapath) && File.GetLastWriteTime(metapath) > File.GetLastWriteTime(outpath);
+
+            return inFileDirty || inMetaDirty;
+        }
     }
 
     /// <summary>
-    /// Base class for a processor which operates on content files and consumes optional metadata
+    /// Base class for simple processors which operate on one file at a time
+    /// Will automatically skip any files which haven't changed
     /// </summary>
-    /// <typeparam name="TMetadata"></typeparam>
-    public abstract class BuildProcessor<TMetadata> : BuildProcessor
+    public abstract class SingleAssetProcessor : BuildProcessor
     {
+        /// <summary>
+        /// Get the output file extension given an input file's extension
+        /// </summary>
+        /// <param name="inputExtension">The extension of the input file</param>
+        /// <returns>The file extension of the output file</returns>
+        protected virtual string GetOutputExtension(string inputExtension)
+        {
+            return inputExtension;
+        }
+
+        /// <summary>
+        /// Process the given input file
+        /// </summary>
+        /// <param name="inputFile">The input file</param>
+        /// <param name="outputPath">The output path to write to</param>
+        protected abstract void Process(BuildInputFile inputFile, string outputPath);
+
+        public override int Process(BuildInputFile[] inputFiles, BuildOptions options)
+        {
+            int errCount = 0;
+
+            Parallel.ForEach(inputFiles, options.parallelOptions, (x) =>
+            {
+                string outpath = GetOutputPath(x.filepath, options.inputDirectory, options.outputDirectory);
+                string outExt = GetOutputExtension(Path.GetExtension(outpath));
+                outpath = Path.ChangeExtension(outpath, outExt);
+
+                Directory.CreateDirectory(Path.GetDirectoryName(outpath));
+
+                if (CheckFileDirty(x.filepath, x.metapath, outpath))
+                {
+                    try
+                    {
+                        Process(x, outpath);
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine($"Failed processing {x.filepath}: {e.Message}");
+                        Interlocked.Increment(ref errCount);
+                    }
+                }
+            });
+
+            return errCount;
+        }
+    }
+
+    /// <summary>
+    /// Base class for simple processors which operate on one file at a time with metadata
+    /// Will automatically skip any files which haven't changed
+    /// </summary>
+    public abstract class SingleAssetProcessor<TMetadata> : SingleAssetProcessor
+    {
+        /// <summary>
+        /// Gets the default metadata to use when no metadata file is supplied
+        /// </summary>
         protected virtual TMetadata DefaultMetadata => default;
 
+        /// <summary>
+        /// Deserialize the metadata from the given file
+        /// </summary>
+        /// <param name="path">The path to the meta file</param>
+        /// <returns>The deserialized metadata</returns>
         protected virtual TMetadata DeserializeMetadata(string path)
         {
             return JsonConvert.DeserializeObject<TMetadata>(File.ReadAllText(path));
         }
 
-        protected abstract void Process(string infile, string outfile, TMetadata meta);
+        protected abstract void Process(BuildInputFile<TMetadata> inputFile, string outputPath);
 
-        public override void Process(string infile, string infileMetadata, string outfile)
+        protected override void Process(BuildInputFile inputFile, string outputPath)
         {
             TMetadata meta = DefaultMetadata;
 
-            if (!string.IsNullOrEmpty(infileMetadata))
+            if (!string.IsNullOrEmpty(inputFile.metapath))
             {
-                meta = DeserializeMetadata(infileMetadata);
+                meta = DeserializeMetadata(inputFile.metapath);
             }
 
-            Process(infile, outfile, meta);
+            var inputWithMeta = new BuildInputFile<TMetadata>
+            {
+                filepath = inputFile.filepath,
+                metapath = inputFile.metapath,
+                metadata = meta
+            };
+
+            Process(inputWithMeta, outputPath);
         }
     }
 
     /// <summary>
-    /// Simple processor which just copies a file to the destination
+    /// Base class for processors which organize input into batches of multiple files each
+    /// Handles only rebuilding batches where at least one input file has changed
     /// </summary>
-    public class CopyProcessor : BuildProcessor
+    public abstract class BatchAssetProcessor : BuildProcessor
     {
-        public override void Process(string infile, string infileMetadata, string outfile)
+        /// <summary>
+        /// A batch of input files which maps to an output file
+        /// </summary>
+        protected struct Batch
         {
-            File.Copy(infile, outfile);
+            /// <summary>
+            /// The input files in this batch
+            /// </summary>
+            public BuildInputFile[] inputfiles;
+
+            /// <summary>
+            /// The output files they map to
+            /// </summary>
+            public string outputfile;
+        }
+
+        /// <summary>
+        /// Gather input files into a set of batches
+        /// </summary>
+        /// <param name="inputFiles">The set of all input files for this processor</param>
+        /// <returns>A set of batches to process</returns>
+        protected abstract Batch[] GatherBatches(BuildInputFile[] inputFiles, BuildOptions options);
+
+        /// <summary>
+        /// Process a batch returned from GatherBatches
+        /// </summary>
+        /// <param name="batch">The batch data</param>
+        protected abstract void ProcessBatch(Batch batch, BuildOptions options);
+
+        public override int Process(BuildInputFile[] inputFiles, BuildOptions options)
+        {
+            // TODO: what if GatherBatches throws?
+            Batch[] batches = GatherBatches(inputFiles, options);
+
+            int errCount = 0;
+
+            Parallel.ForEach(batches, options.parallelOptions, (x) =>
+            {
+                bool dirty = false;
+
+                foreach (var inputFile in x.inputfiles)
+                {
+                    if (CheckFileDirty(inputFile.filepath, inputFile.metapath, x.outputfile))
+                    {
+                        dirty = true;
+                        break;
+                    }
+                }
+
+                if (dirty)
+                {
+                    try
+                    {
+                        ProcessBatch(x, options);
+                    }
+                    catch(Exception e)
+                    {
+                        // TODO: should this count as one error per input file, or just one error per batch?
+                        Interlocked.Increment(ref errCount);
+                    }
+                }
+            });
+
+            return errCount;
+        }
+    }
+
+    /// <summary>
+    /// Base class for processors which organize input into batches of multiple files each and consume JSON-formatted metadata
+    /// Handles only rebuilding batches where at least one input file has changed
+    /// </summary>
+    public abstract class BatchAssetProcessor<TMetadata> : BuildProcessor
+    {
+        /// <summary>
+        /// A batch of input files which maps to an output file
+        /// </summary>
+        protected struct Batch
+        {
+            /// <summary>
+            /// The input files in this batch
+            /// </summary>
+            public BuildInputFile<TMetadata>[] inputfiles;
+
+            /// <summary>
+            /// The output files they map to
+            /// </summary>
+            public string outputfile;
+        }
+
+        /// <summary>
+        /// Gets the default metadata to use when no metadata file is supplied
+        /// </summary>
+        protected virtual TMetadata DefaultMetadata => default;
+
+        /// <summary>
+        /// Deserialize the metadata from the given file
+        /// </summary>
+        /// <param name="path">The path to the meta file</param>
+        /// <returns>The deserialized metadata</returns>
+        protected virtual TMetadata DeserializeMetadata(string path)
+        {
+            return JsonConvert.DeserializeObject<TMetadata>(File.ReadAllText(path));
+        }
+
+        /// <summary>
+        /// Gather input files into a set of batches
+        /// </summary>
+        /// <param name="inputFiles">The set of all input files for this processor</param>
+        /// <returns>A set of batches to process</returns>
+        protected abstract Batch[] GatherBatches(BuildInputFile<TMetadata>[] inputFiles, BuildOptions options);
+
+        /// <summary>
+        /// Process a batch returned from GatherBatches
+        /// </summary>
+        /// <param name="batch">The batch data</param>
+        protected abstract void ProcessBatch(Batch batch, BuildOptions options);
+
+        public override int Process(BuildInputFile[] inputFiles, BuildOptions options)
+        {
+            int errCount = 0;
+            BuildInputFile<TMetadata>[] inputFilesWithMeta = new BuildInputFile<TMetadata>[inputFiles.Length];
+
+            // load metadata for all input files
+            Parallel.For(0, inputFiles.Length, options.parallelOptions, (i) =>
+            {
+                TMetadata meta = DefaultMetadata;
+
+                if (File.Exists(inputFiles[i].metapath))
+                {
+                    try
+                    {
+                        meta = DeserializeMetadata(inputFiles[i].metapath);
+                    }
+                    catch(Exception e)
+                    {
+                        Console.WriteLine($"Failed reading {inputFiles[i].metapath}: {e.Message}");
+                        Interlocked.Increment(ref errCount);
+                        meta = DefaultMetadata;
+                    }
+                }
+
+                inputFilesWithMeta[i] = new BuildInputFile<TMetadata>
+                {
+                    filepath = inputFiles[i].filepath,
+                    metapath = inputFiles[i].metapath,
+                    metadata = meta,
+                };
+            });
+
+            // TODO: what if GatherBatches throws?
+            Batch[] batches = GatherBatches(inputFilesWithMeta, options);
+
+            Parallel.ForEach(batches, options.parallelOptions, (x) =>
+            {
+                bool dirty = false;
+
+                foreach (var inputFile in x.inputfiles)
+                {
+                    if (CheckFileDirty(inputFile.filepath, inputFile.metapath, x.outputfile))
+                    {
+                        dirty = true;
+                        break;
+                    }
+                }
+
+                if (dirty)
+                {
+                    try
+                    {
+                        ProcessBatch(x, options);
+                    }
+                    catch (Exception e)
+                    {
+                        // TODO: should this count as one error per input file, or just one error per batch?
+                        Interlocked.Increment(ref errCount);
+                    }
+                }
+            });
+
+            return errCount;
+        }
+    }
+
+    /// <summary>
+    /// Simple processor which just copies input files to the destination
+    /// </summary>
+    public class CopyProcessor : SingleAssetProcessor
+    {
+        protected override void Process(BuildInputFile inputFile, string outputPath)
+        {
+            File.Copy(inputFile.filepath, outputPath, true);
         }
     }
 
@@ -61,7 +420,7 @@ namespace ContentPipe.Core
     /// </summary>
     public class DummyProcessor : BuildProcessor
     {
-        public override void Process(string infile, string infileMetadata, string outfile)
+        public override int Process(BuildInputFile[] inputFiles, BuildOptions options)
         {
             throw new NotImplementedException();
         }

--- a/ContentPipe.Example/Program.cs
+++ b/ContentPipe.Example/Program.cs
@@ -11,8 +11,10 @@ namespace ContentPipe.Test
         static int Main(string[] args)
         {
             var builder = new Builder();
-            builder.AddRule("txt", new CopyProcessor());
-            builder.AddRule("png", new QoiProcessor());
+            //builder.AddRule("txt", new CopyProcessor());
+            builder.AddRule("txt", new ArchiveProcessor("data.zip"));
+            //builder.AddRule("png", new QoiProcessor());
+            builder.AddRule("png", new TexturePackerProcessor("img"));
             builder.AddRule("json", new JsonProcessor());
             builder.AddRule("fx", new FNAShaderProcessor("./tool/efb.exe", null));
             builder.AddRule("vert", new VulkanShaderProcessor("./tool/glslangValidator.exe", null));

--- a/ContentPipe.Example/src/images/glairedaggers.png.meta
+++ b/ContentPipe.Example/src/images/glairedaggers.png.meta
@@ -1,4 +1,3 @@
 ﻿{
-	"channels": "Rgb",
-	"colorSpace": "Linear"
+	"textureSheetId": "default"
 }

--- a/ContentPipe.Extras/ArchiveProcessor.cs
+++ b/ContentPipe.Extras/ArchiveProcessor.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using System.IO.Compression;
+
+using ContentPipe.Core;
+
+namespace ContentPipe.Extras
+{
+    /// <summary>
+    /// Example asset processor which appends all input files to an output ZIP
+    /// </summary>
+    public class ArchiveProcessor : BatchAssetProcessor
+    {
+        private readonly string _outputZip;
+
+        public ArchiveProcessor(string outputZip)
+        {
+            _outputZip = outputZip;
+        }
+
+        protected override Batch[] GatherBatches(BuildInputFile[] inputFiles, BuildOptions options)
+        {
+            return new Batch[]
+            {
+                new Batch() { inputfiles = inputFiles, outputfile = Path.Combine(options.outputDirectory, _outputZip) }
+            };
+        }
+
+        protected override void ProcessBatch(Batch batch, BuildOptions options)
+        {
+            using (ZipArchive archive = ZipFile.Open(batch.outputfile, ZipArchiveMode.Create))
+            {
+                foreach (var inputfile in batch.inputfiles)
+                {
+                    archive.CreateEntryFromFile(inputfile.filepath, MakeRelativePath(inputfile.filepath, options.inputDirectory));
+                }
+            }
+        }
+    }
+}

--- a/ContentPipe.Extras/ContentPipe.Extras.csproj
+++ b/ContentPipe.Extras/ContentPipe.Extras.csproj
@@ -39,12 +39,17 @@
     <Reference Include="Newtonsoft.Json.Bson, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.Bson.1.0.2\lib\net45\Newtonsoft.Json.Bson.dll</HintPath>
     </Reference>
+    <Reference Include="StbRectPackSharp, Version=1.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StbRectPackSharp.1.0.4\lib\net45\StbRectPackSharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
@@ -63,10 +68,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArchiveProcessor.cs" />
     <Compile Include="GzipProcessor.cs" />
     <Compile Include="JsonProcessor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QoiProcessor.cs" />
+    <Compile Include="TexturePackerProcessor.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ContentPipe.Core\ContentPipe.Core.csproj">

--- a/ContentPipe.Extras/GzipProcessor.cs
+++ b/ContentPipe.Extras/GzipProcessor.cs
@@ -10,7 +10,7 @@ namespace ContentPipe.Extras
     /// <summary>
     /// Processor which compresses input content into a GZipped file
     /// </summary>
-    public class GzipProcessor : BuildProcessor<GzipProcessor.GzipMetadata>
+    public class GzipProcessor : SingleAssetProcessor<GzipProcessor.GzipMetadata>
     {
         public struct GzipMetadata
         {
@@ -20,16 +20,16 @@ namespace ContentPipe.Extras
 
         protected override GzipMetadata DefaultMetadata => new GzipMetadata { level = CompressionLevel.Optimal };
 
-        public override string GetOutputExtension(string inFileExtension)
+        protected override string GetOutputExtension(string inFileExtension)
         {
             return inFileExtension + ".gz";
         }
 
-        protected override void Process(string infile, string outfile, GzipMetadata meta)
+        protected override void Process(BuildInputFile<GzipMetadata> inputFile, string outputPath)
         {
-            using (var instream = File.OpenRead(infile))
-            using (var outstream = File.OpenWrite(outfile))
-            using (var compressor = new GZipStream(outstream, meta.level))
+            using (var instream = File.OpenRead(inputFile.filepath))
+            using (var outstream = File.OpenWrite(outputPath))
+            using (var compressor = new GZipStream(outstream, inputFile.metadata.level))
             {
                 instream.CopyTo(compressor);
             }

--- a/ContentPipe.Extras/JsonProcessor.cs
+++ b/ContentPipe.Extras/JsonProcessor.cs
@@ -9,18 +9,18 @@ namespace ContentPipe.Extras
     /// <summary>
     /// Content processor which converts source JSON files into equivalent BSON files
     /// </summary>
-    public class JsonProcessor : BuildProcessor
+    public class JsonProcessor : SingleAssetProcessor
     {
-        public override string GetOutputExtension(string inFileExtension)
+        protected override string GetOutputExtension(string inFileExtension)
         {
             return inFileExtension + ".b";
         }
 
-        public override void Process(string infile, string infileMetadata, string outfile)
+        protected override void Process(BuildInputFile inputFile, string outputPath)
         {
-            using (var reader = File.OpenText(infile))
+            using (var reader = File.OpenText(inputFile.filepath))
             using (var jsonReader = new JsonTextReader(reader))
-            using (var outstream = File.OpenWrite(outfile))
+            using (var outstream = File.OpenWrite(outputPath))
             using (var writer = new BsonDataWriter(outstream))
             {
                 writer.WriteToken(jsonReader);

--- a/ContentPipe.Extras/QoiProcessor.cs
+++ b/ContentPipe.Extras/QoiProcessor.cs
@@ -15,8 +15,55 @@ namespace ContentPipe.Extras
     /// Content processor which converts source PNG files into QOI files
     /// https://github.com/phoboslab/qoi
     /// </summary>
-    public class QoiProcessor : BuildProcessor<QoiProcessor.QoiMetadata>
+    public class QoiProcessor : SingleAssetProcessor<QoiProcessor.QoiMetadata>
     {
+        public static QoiImage BmpToQoiImage(Bitmap bmp, Channels channels, ColorSpace colorSpace)
+        {
+            int fmtSize = (int)channels;
+
+            var bmpData = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+            byte[] srcBytes = new byte[bmp.Width * bmp.Height * 4];
+            byte[] dstBytes = new byte[bmp.Width * bmp.Height * fmtSize];
+
+            // copy bitmap data to srcBytes array
+            unsafe
+            {
+                fixed (void* bytePtr = srcBytes)
+                {
+                    Unsafe.CopyBlock(bytePtr, (void*)bmpData.Scan0, (uint)srcBytes.Length);
+                }
+            }
+
+            bmp.UnlockBits(bmpData);
+
+            if (channels == Channels.Rgb)
+            {
+                // we need to swizzle from bgr to rgb
+                int dstIdx = 0;
+                for (int px = 0; px < srcBytes.Length; px += 4)
+                {
+                    dstBytes[dstIdx + 2] = srcBytes[px + 0]; // b
+                    dstBytes[dstIdx + 1] = srcBytes[px + 1]; // g
+                    dstBytes[dstIdx + 0] = srcBytes[px + 2]; // r
+                    dstIdx += 3;
+                }
+            }
+            else
+            {
+                // we need to swizzle from bgra to rgba
+                for (int px = 0; px < dstBytes.Length; px += 4)
+                {
+                    dstBytes[px + 2] = srcBytes[px + 0]; // b
+                    dstBytes[px + 1] = srcBytes[px + 1]; // g
+                    dstBytes[px + 0] = srcBytes[px + 2]; // r
+                    dstBytes[px + 3] = srcBytes[px + 3]; // a
+                }
+            }
+
+            // convert into a QOI image
+            return new QoiImage(dstBytes, bmp.Width, bmp.Height, channels, colorSpace);
+        }
+
         public struct QoiMetadata
         {
             [JsonConverter(typeof(StringEnumConverter))]
@@ -28,62 +75,21 @@ namespace ContentPipe.Extras
 
         protected override QoiMetadata DefaultMetadata => new QoiMetadata { channels = Channels.RgbWithAlpha, colorSpace = ColorSpace.SRgb };
 
-        public override string GetOutputExtension(string inFileExtension)
+        protected override string GetOutputExtension(string inFileExtension)
         {
             return "qoi";
         }
 
-        protected override void Process(string infile, string outfile, QoiMetadata meta)
+        protected override void Process(BuildInputFile<QoiMetadata> inputFile, string outputPath)
         {
-            using (var srcImage = Image.FromFile(infile))
+            using (var srcImage = Image.FromFile(inputFile.filepath))
             using (var bmp = new Bitmap(srcImage))
             {
-                int fmtSize = (int)meta.channels;
-
-                var bmpData = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
-                byte[] srcBytes = new byte[bmp.Width * bmp.Height * 4];
-                byte[] dstBytes = new byte[bmp.Width * bmp.Height * fmtSize];
-
-                // copy bitmap data to srcBytes array
-                unsafe
-                {
-                    fixed (void* bytePtr = srcBytes)
-                    {
-                        Unsafe.CopyBlock(bytePtr, (void*)bmpData.Scan0, (uint)srcBytes.Length);
-                    }
-                }
-
-                bmp.UnlockBits(bmpData);
-
-                if (meta.channels == Channels.Rgb)
-                {
-                    // we need to swizzle from bgr to rgb
-                    int dstIdx = 0;
-                    for (int px = 0; px < srcBytes.Length; px += 4)
-                    {
-                        dstBytes[dstIdx + 2] = srcBytes[px + 0]; // b
-                        dstBytes[dstIdx + 1] = srcBytes[px + 1]; // g
-                        dstBytes[dstIdx + 0] = srcBytes[px + 2]; // r
-                        dstIdx += 3;
-                    }
-                }
-                else
-                {
-                    // we need to swizzle from bgra to rgba
-                    for (int px = 0; px < dstBytes.Length; px += 4)
-                    {
-                        dstBytes[px + 2] = srcBytes[px + 0]; // b
-                        dstBytes[px + 1] = srcBytes[px + 1]; // g
-                        dstBytes[px + 0] = srcBytes[px + 2]; // r
-                        dstBytes[px + 3] = srcBytes[px + 3]; // a
-                    }
-                }
-
                 // convert into a QOI image
-                QoiImage image = new QoiImage(dstBytes, bmp.Width, bmp.Height, meta.channels, meta.colorSpace);
+                QoiImage image = BmpToQoiImage(bmp, inputFile.metadata.channels, inputFile.metadata.colorSpace);
 
                 // encode to output
-                using (var outstream = File.OpenWrite(outfile))
+                using (var outstream = File.OpenWrite(outputPath))
                 {
                     byte[] data = QoiEncoder.Encode(image);
                     outstream.Write(data, 0, data.Length);

--- a/ContentPipe.Extras/TexturePackerProcessor.cs
+++ b/ContentPipe.Extras/TexturePackerProcessor.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+using StbRectPackSharp;
+using System.Drawing;
+using System.Drawing.Imaging;
+using QoiSharp;
+using QoiSharp.Codec;
+using Newtonsoft.Json;
+
+using ContentPipe.Core;
+
+namespace ContentPipe.Extras
+{
+    public class TexturePackerProcessor : BatchAssetProcessor<TexturePackerProcessor.Metadata>
+    {
+        public struct TextureSheetRect
+        {
+            public int x;
+            public int y;
+            public int width;
+            public int height;
+        }
+
+        public struct TextureSheetData
+        {
+            public Dictionary<string, TextureSheetRect> images;
+        }
+
+        public struct Metadata
+        {
+            public string textureSheetId;
+        }
+
+        protected override Metadata DefaultMetadata => new Metadata { textureSheetId = "default" };
+
+        protected readonly string _outputPath;
+
+        public TexturePackerProcessor(string outputPath)
+        {
+            _outputPath = outputPath;
+        }
+
+        protected override Batch[] GatherBatches(BuildInputFile<Metadata>[] inputFiles, BuildOptions options)
+        {
+            Dictionary<string, List<BuildInputFile<Metadata>>> sheets = new Dictionary<string, List<BuildInputFile<Metadata>>>();
+
+            // sort input files by texture sheet ID
+            foreach (var inputfile in inputFiles)
+            {
+                if (!sheets.ContainsKey(inputfile.metadata.textureSheetId))
+                {
+                    sheets.Add(inputfile.metadata.textureSheetId, new List<BuildInputFile<Metadata>>());
+                }
+
+                sheets[inputfile.metadata.textureSheetId].Add(inputfile);
+            }
+
+            List<Batch> batches = new List<Batch>();
+
+            foreach (var kvp in sheets)
+            {
+                batches.Add(new Batch()
+                {
+                    inputfiles = kvp.Value.ToArray(),
+                    outputfile = Path.Combine(options.outputDirectory, $"{kvp.Key}.qoi")
+                });
+            }
+
+            return batches.ToArray();
+        }
+
+        protected override void ProcessBatch(Batch batch, BuildOptions options)
+        {
+            Image[] imgArray = new Image[batch.inputfiles.Length];
+
+            // load all input images
+            for (int i = 0; i < batch.inputfiles.Length; i++)
+            {
+                imgArray[i] = Image.FromFile(batch.inputfiles[i].filepath);
+            }
+
+            // pack image rects
+            Packer packer = new Packer();
+
+            for (int i = 0; i < imgArray.Length; i++)
+            {
+                PackerRectangle pr = packer.PackRect(imgArray[i].Width, imgArray[i].Height, i);
+
+                while (pr == null)
+                {
+                    // TODO: if we exceed maximum size, we need to give up
+
+                    // ran out of room, try resizing
+                    Packer newPacker = new Packer(packer.Width * 2, packer.Height * 2);
+
+                    // Place existing rectangles
+                    foreach (PackerRectangle existingRect in packer.PackRectangles)
+                    {
+                        newPacker.PackRect(existingRect.Width, existingRect.Height, existingRect.Data);
+                    }
+
+                    // Now dispose old packer and assign new one
+                    packer.Dispose();
+                    packer = newPacker;
+
+                    // try again
+                    pr = packer.PackRect(imgArray[i].Width, imgArray[i].Height, i);
+                }
+            }
+
+            // create atlas & blit images into it
+            Bitmap atlasBmp = new Bitmap(packer.Width, packer.Height, PixelFormat.Format32bppArgb);
+            Graphics g = Graphics.FromImage(atlasBmp);
+
+            foreach (var packedRect in packer.PackRectangles)
+            {
+                Rectangle srcRect = new Rectangle(0, 0, packedRect.Width, packedRect.Height);
+                Rectangle dstRect = new Rectangle(packedRect.X, packedRect.Y, packedRect.Width, packedRect.Height);
+                Image img = imgArray[(int)packedRect.Data];
+                g.DrawImage(img, dstRect, srcRect, GraphicsUnit.Pixel);
+            }
+
+            // also build atlas data
+            TextureSheetData sheetData = new TextureSheetData() { images = new Dictionary<string, TextureSheetRect>() };
+
+            foreach (var packedRect in packer.PackRectangles)
+            {
+                TextureSheetRect dstRect = new TextureSheetRect { x = packedRect.X, y = packedRect.Y, width = packedRect.Width, height = packedRect.Height };
+                var inputFile = batch.inputfiles[(int)packedRect.Data];
+                var fileid = MakeRelativePath(inputFile.filepath, options.inputDirectory);
+                sheetData.images.Add(fileid, dstRect);
+            }
+
+            // now convert into QoiImage
+            QoiImage qoiImage = QoiProcessor.BmpToQoiImage(atlasBmp, Channels.RgbWithAlpha, ColorSpace.SRgb);
+
+            // we don't need atlasBmp or any of the original images anymore
+            atlasBmp.Dispose();
+
+            foreach (var img in imgArray)
+            {
+                img.Dispose();
+            }
+
+            // encode to output
+            using (var outstream = File.OpenWrite(batch.outputfile))
+            {
+                byte[] data = QoiEncoder.Encode(qoiImage);
+                outstream.Write(data, 0, data.Length);
+            }
+
+            // also write atlas data
+            File.WriteAllText(batch.outputfile + ".json", JsonConvert.SerializeObject(sheetData));
+        }
+    }
+}

--- a/ContentPipe.Extras/packages.config
+++ b/ContentPipe.Extras/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
   <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net472" />
+  <package id="StbRectPackSharp" version="1.0.4" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.5" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />

--- a/ContentPipe.FNA/ShaderProcessor.cs
+++ b/ContentPipe.FNA/ShaderProcessor.cs
@@ -11,7 +11,7 @@ namespace ContentPipe.FNA
     /// <summary>
     /// A processor for shader files which invokes an fxc or compatible executable to compile HLSL shaders into DXBC for FNA games
     /// </summary>
-    public class ShaderProcessor : BuildProcessor<ShaderProcessor.ShaderMetadata>
+    public class ShaderProcessor : SingleAssetProcessor<ShaderProcessor.ShaderMetadata>
     {
         public enum ShaderOptimizationLevel
         {
@@ -56,12 +56,12 @@ namespace ContentPipe.FNA
             matrixPacking = ShaderMatrixPacking.ColumnOrder,
         };
 
-        public override string GetOutputExtension(string inFileExtension)
+        protected override string GetOutputExtension(string inFileExtension)
         {
             return "fxo";
         }
 
-        protected override void Process(string infile, string outfile, ShaderMetadata meta)
+        protected override void Process(BuildInputFile<ShaderMetadata> inputFile, string outputPath)
         {
             string fxcArgs = "";
 
@@ -83,19 +83,19 @@ namespace ContentPipe.FNA
                 fxcArgs += " /WX";
             }
 
-            if (meta.matrixPacking == ShaderMatrixPacking.ColumnOrder)
+            if (inputFile.metadata.matrixPacking == ShaderMatrixPacking.ColumnOrder)
             {
                 fxcArgs += " /Zpc";
             }
-            else if(meta.matrixPacking == ShaderMatrixPacking.RowOrder)
+            else if (inputFile.metadata.matrixPacking == ShaderMatrixPacking.RowOrder)
             {
                 fxcArgs += " /Zpr";
             }
 
-            fxcArgs += $" /{meta.optLevel}";
+            fxcArgs += $" /{inputFile.metadata.optLevel}";
 
             // invoke FXC
-            string cmd = $"{fxcArgs} {infile} {outfile}";
+            string cmd = $"{fxcArgs} {inputFile.filepath} {outputPath}";
 
             Process process = new Process();
             ProcessStartInfo startInfo = new ProcessStartInfo();

--- a/ContentPipe.Vulkan/ShaderProcessor.cs
+++ b/ContentPipe.Vulkan/ShaderProcessor.cs
@@ -8,7 +8,7 @@ namespace ContentPipe.Vulkan
     /// <summary>
     /// A processor for shader files which invokes a glslangValidator or compatible executable to compile GLSL shaders into SPIR-V for Vulkan games
     /// </summary>
-    public class ShaderProcessor : BuildProcessor
+    public class ShaderProcessor : SingleAssetProcessor
     {
         private readonly string _glslangPath;
         private readonly string[] _includePaths;
@@ -19,12 +19,12 @@ namespace ContentPipe.Vulkan
             _includePaths = includePaths;
         }
 
-        public override string GetOutputExtension(string inFileExtension)
+        protected override string GetOutputExtension(string inFileExtension)
         {
             return inFileExtension + ".spv";
         }
 
-        public override void Process(string infile, string infileMetadata, string outfile)
+        protected override void Process(BuildInputFile inputFile, string outputPath)
         {
             string glslangArgs = "";
 
@@ -37,7 +37,7 @@ namespace ContentPipe.Vulkan
             }
 
             // invoke glslangValidator
-            string cmd = $"{glslangArgs} -V {infile} -o {outfile}";
+            string cmd = $"{glslangArgs} -V {inputFile.filepath} -o {outputPath}";
 
             Process process = new Process();
             ProcessStartInfo startInfo = new ProcessStartInfo();


### PR DESCRIPTION
+ Refactored BuildProcessor to take all input files rather than one file at a time
+ Added new SingleAssetProcessor to replace legacy behavior
+ Added new BatchAssetProcessor which splits input files into multiple batches, where each batch maps to one main output file, and operates on each batch in parallel.