### PR TITLE
.NET Core/5/6 project files

### DIFF
--- a/ContentPipe.Core/ContentPipe.Core.NETCore.csproj
+++ b/ContentPipe.Core/ContentPipe.Core.NETCore.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
+    <LangVersion>7.3</LangVersion>
+
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
+  </ItemGroup>
+
+</Project>

--- a/ContentPipe.Example/ContentPipe.Example.NETCore.csproj
+++ b/ContentPipe.Example/ContentPipe.Example.NETCore.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ContentPipe.Core\ContentPipe.Core.NETCore.csproj"/>
+    <ProjectReference Include="..\ContentPipe.Extras\ContentPipe.Extras.NETCore.csproj"/>
+    <ProjectReference Include="..\ContentPipe.FNA\ContentPipe.FNA.NETCore.csproj"/>
+    <ProjectReference Include="..\ContentPipe.Vulkan\ContentPipe.Vulkan.NETCore.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/ContentPipe.Extras/ContentPipe.Extras.NETCore.csproj
+++ b/ContentPipe.Extras/ContentPipe.Extras.NETCore.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
+    <LangVersion>7.3</LangVersion>
+
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ContentPipe.Core\ContentPipe.Core.NETCore.csproj"/>
+    <ProjectReference Include="..\QoiSharp\QoiSharp.NETCore.csproj"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3-beta1"/>
+    <PackageReference Include="StbImageSharp" Version="2.27.13"/>
+    <PackageReference Include="StbRectPackSharp" Version="1.0.4"/>
+  </ItemGroup>
+
+</Project>

--- a/ContentPipe.FNA/ContentPipe.FNA.NETCore.csproj
+++ b/ContentPipe.FNA/ContentPipe.FNA.NETCore.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
+    <LangVersion>7.3</LangVersion>
+
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ContentPipe.Core\ContentPipe.Core.NETCore.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/ContentPipe.NETCore.sln
+++ b/ContentPipe.NETCore.sln
@@ -1,0 +1,46 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContentPipe.Core.NETCore", "ContentPipe.Core\ContentPipe.Core.NETCore.csproj", "{4AD56074-3EBC-4E09-93B7-99D4E721C402}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContentPipe.Example.NETCore", "ContentPipe.Example\ContentPipe.Example.NETCore.csproj", "{5B4F192D-4EE9-4417-A632-DA0A047BFDE9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContentPipe.Extras.NETCore", "ContentPipe.Extras\ContentPipe.Extras.NETCore.csproj", "{B7BE5653-B9F7-46D9-9FCE-0240DFD33483}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QoiSharp.NETCore", "QoiSharp\QoiSharp.NETCore.csproj", "{7A6EAC88-1A77-4468-A2D7-F901EBD33D81}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContentPipe.FNA.NETCore", "ContentPipe.FNA\ContentPipe.FNA.NETCore.csproj", "{0D3B880A-7FE7-4579-B2DB-8795211BA4CA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ContentPipe.Vulkan.NETCore", "ContentPipe.Vulkan\ContentPipe.Vulkan.NETCore.csproj", "{202EAE48-3F70-4CDB-AFC5-B9ED90E873A3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4AD56074-3EBC-4E09-93B7-99D4E721C402}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AD56074-3EBC-4E09-93B7-99D4E721C402}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AD56074-3EBC-4E09-93B7-99D4E721C402}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AD56074-3EBC-4E09-93B7-99D4E721C402}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B4F192D-4EE9-4417-A632-DA0A047BFDE9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B4F192D-4EE9-4417-A632-DA0A047BFDE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B4F192D-4EE9-4417-A632-DA0A047BFDE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B4F192D-4EE9-4417-A632-DA0A047BFDE9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7BE5653-B9F7-46D9-9FCE-0240DFD33483}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7BE5653-B9F7-46D9-9FCE-0240DFD33483}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7BE5653-B9F7-46D9-9FCE-0240DFD33483}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7BE5653-B9F7-46D9-9FCE-0240DFD33483}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A6EAC88-1A77-4468-A2D7-F901EBD33D81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A6EAC88-1A77-4468-A2D7-F901EBD33D81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A6EAC88-1A77-4468-A2D7-F901EBD33D81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A6EAC88-1A77-4468-A2D7-F901EBD33D81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D3B880A-7FE7-4579-B2DB-8795211BA4CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D3B880A-7FE7-4579-B2DB-8795211BA4CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D3B880A-7FE7-4579-B2DB-8795211BA4CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D3B880A-7FE7-4579-B2DB-8795211BA4CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{202EAE48-3F70-4CDB-AFC5-B9ED90E873A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{202EAE48-3F70-4CDB-AFC5-B9ED90E873A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{202EAE48-3F70-4CDB-AFC5-B9ED90E873A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{202EAE48-3F70-4CDB-AFC5-B9ED90E873A3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/ContentPipe.Vulkan/ContentPipe.Vulkan.NETCore.csproj
+++ b/ContentPipe.Vulkan/ContentPipe.Vulkan.NETCore.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
+    <LangVersion>7.3</LangVersion>
+
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ContentPipe.Core\ContentPipe.Core.NETCore.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/QoiSharp/QoiSharp.NETCore.csproj
+++ b/QoiSharp/QoiSharp.NETCore.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net6.0;net5.0</TargetFrameworks>
+    <LangVersion>7.3</LangVersion>
+    <RootNamespace>QoiSharp</RootNamespace>
+
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+    <Authors>Eugene Antonov</Authors>
+    <PackageId>QoiSharp</PackageId>
+    <PackageVersion>1.0.0</PackageVersion>
+    <PackageProjectUrl>https://github.com/NUlliiON/QoiSharp</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>QOI Fast Image Jpg Jpeg Bitmap Png Net5 Net6</PackageTags>
+    <RepositoryUrl>https://github.com/NUlliiON/QoiSharp</RepositoryUrl>
+    <Description>QoiSharp is an implementation of the QOI format for fast lossless image compression</Description>
+    <Title>QoiSharp</Title>
+
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Useful for if, say, you were using [MoonWorks](https://gitea.moonside.games/MoonsideGames/MoonWorks) which only supports .NET 6.

`.NETCore.csproj` suffix was chosen instead of `.Core.csproj` to not conflict with the existing `ContentPipe.Core` project.