### PR TITLE
Relax .NET Core version restrictions to the bare minimum

### DIFF
--- a/ContentPipe.Core/ContentPipe.Core.NETCore.csproj
+++ b/ContentPipe.Core/ContentPipe.Core.NETCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/ContentPipe.Extras/ContentPipe.Extras.NETCore.csproj
+++ b/ContentPipe.Extras/ContentPipe.Extras.NETCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/ContentPipe.FNA/ContentPipe.FNA.NETCore.csproj
+++ b/ContentPipe.FNA/ContentPipe.FNA.NETCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/ContentPipe.Vulkan/ContentPipe.Vulkan.NETCore.csproj
+++ b/ContentPipe.Vulkan/ContentPipe.Vulkan.NETCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5;net6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/QoiSharp/QoiSharp.NETCore.csproj
+++ b/QoiSharp/QoiSharp.NETCore.csproj
@@ -1,21 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <RootNamespace>QoiSharp</RootNamespace>
-
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-
-    <Authors>Eugene Antonov</Authors>
-    <PackageId>QoiSharp</PackageId>
-    <PackageVersion>1.0.0</PackageVersion>
-    <PackageProjectUrl>https://github.com/NUlliiON/QoiSharp</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageTags>QOI Fast Image Jpg Jpeg Bitmap Png Net5 Net6</PackageTags>
-    <RepositoryUrl>https://github.com/NUlliiON/QoiSharp</RepositoryUrl>
-    <Description>QoiSharp is an implementation of the QOI format for fast lossless image compression</Description>
-    <Title>QoiSharp</Title>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>


### PR DESCRIPTION
Notably, this makes most of the libraries also fully compatible with FNA's .NET Core TargetFrameworks.